### PR TITLE
build(man): add missing standard-specifiers.xml

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -45,6 +45,7 @@ download-docs:
 		'https://github.com/systemd/systemd/raw/main/man/custom-html.xsl' \
 		'https://github.com/systemd/systemd/raw/main/man/custom-man.xsl' \
 		'https://github.com/systemd/systemd/raw/main/man/standard-options.xml' \
+		'https://github.com/systemd/systemd/raw/main/man/standard-specifiers.xml' \
 		'https://github.com/systemd/systemd/raw/main/man/systemd-sysusers.xml' \
 		'https://github.com/systemd/systemd/raw/main/man/sysusers.d.xml' \
 		'https://github.com/systemd/systemd/raw/main/docs/UIDS-GIDS.md' \

--- a/man/standard-specifiers.xml
+++ b/man/standard-specifiers.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+  "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
+<tbody>
+  <!-- note: units also use the following deprecated specifiers that are not documented:
+       %c, %r, %R. Do not reuse. -->
+
+  <row id='a'>
+    <entry><literal>%a</literal></entry>
+    <entry>Architecture</entry>
+    <entry>A short string identifying the architecture of the local system. A string such as <constant>x86</constant>, <constant>x86-64</constant> or <constant>arm64</constant>. See the architectures defined for <varname>ConditionArchitecture=</varname> in <citerefentry><refentrytitle>systemd.unit</refentrytitle><manvolnum>5</manvolnum></citerefentry> for a full list.</entry>
+  </row>
+  <row id='A'>
+    <entry><literal>%A</literal></entry>
+    <entry>Operating system image version</entry>
+    <entry>The operating system image version identifier of the running system, as read from the <varname>IMAGE_VERSION=</varname> field of <filename>/etc/os-release</filename>. If not set, resolves to an empty string. See <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='b'>
+    <entry><literal>%b</literal></entry>
+    <entry>Boot ID</entry>
+    <entry>The boot ID of the running system, formatted as string. See <citerefentry><refentrytitle>random</refentrytitle><manvolnum>4</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='B'>
+    <entry><literal>%B</literal></entry>
+    <entry>Operating system build ID</entry>
+    <entry>The operating system build identifier of the running system, as read from the <varname>BUILD_ID=</varname> field of <filename>/etc/os-release</filename>. If not set, resolves to an empty string. See <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='H'>
+    <entry><literal>%H</literal></entry>
+    <entry>Host name</entry>
+    <entry>The hostname of the running system.</entry>
+  </row>
+  <row id='l'>
+    <entry><literal>%l</literal></entry>
+    <entry>Short host name</entry>
+    <entry>The hostname of the running system, truncated at the first dot to remove any domain component.</entry>
+  </row>
+  <row id='m'>
+    <entry><literal>%m</literal></entry>
+    <entry>Machine ID</entry>
+    <entry>The machine ID of the running system, formatted as string. See <citerefentry><refentrytitle>machine-id</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='M'>
+    <entry><literal>%M</literal></entry>
+    <entry>Operating system image identifier</entry>
+    <entry>The operating system image identifier of the running system, as read from the <varname>IMAGE_ID=</varname> field of <filename>/etc/os-release</filename>. If not set, resolves to an empty string. See <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='o'>
+    <entry><literal>%o</literal></entry>
+    <entry>Operating system ID</entry>
+    <entry>The operating system identifier of the running system, as read from the <varname>ID=</varname> field of <filename>/etc/os-release</filename>. See <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='q'>
+    <entry><literal>%q</literal></entry>
+    <entry>Pretty host name</entry>
+    <entry>The pretty hostname of the running system, as read from the <varname>PRETTY_HOSTNAME=</varname> field of <filename>/etc/machine-info</filename>. If not set, resolves to the short hostname. See <citerefentry><refentrytitle>machine-info</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='T'>
+    <entry><literal>%T</literal></entry>
+    <entry>Directory for temporary files</entry>
+    <entry>This is either <filename>/tmp<!-- no / --></filename> or the path <literal>$TMPDIR</literal>, <literal>$TEMP</literal> or <literal>$TMP</literal> are set to. (Note that the directory may be specified without a trailing slash.)</entry>
+  </row>
+  <row id='v'>
+    <entry><literal>%v</literal></entry>
+    <entry>Kernel release</entry>
+    <entry>Identical to <command>uname -r</command> output.</entry>
+  </row>
+  <row id='V'>
+    <entry><literal>%V</literal></entry>
+    <entry>Directory for larger and persistent temporary files</entry>
+    <entry>This is either <filename>/var/tmp<!-- no / --></filename> or the path <literal>$TMPDIR</literal>, <literal>$TEMP</literal> or <literal>$TMP</literal> are set to. (Note that the directory may be specified without a trailing slash.)</entry>
+  </row>
+  <row id='w'>
+    <entry><literal>%w</literal></entry>
+    <entry>Operating system version ID</entry>
+    <entry>The operating system version identifier of the running system, as read from the <varname>VERSION_ID=</varname> field of <filename>/etc/os-release</filename>. If not set, resolves to an empty string. See <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='W'>
+    <entry><literal>%W</literal></entry>
+    <entry>Operating system variant ID</entry>
+    <entry>The operating system variant identifier of the running system, as read from the <varname>VARIANT_ID=</varname> field of <filename>/etc/os-release</filename>. If not set, resolves to an empty string. See <citerefentry><refentrytitle>os-release</refentrytitle><manvolnum>5</manvolnum></citerefentry> for more information.</entry>
+  </row>
+  <row id='percent'>
+    <entry><literal>%%</literal></entry>
+    <entry>Single percent sign</entry>
+    <entry>Use <literal>%%</literal> in place of <literal>%</literal> to specify a single percent sign.</entry>
+  </row>
+</tbody>

--- a/man/systemd-sysusers.xml
+++ b/man/systemd-sysusers.xml
@@ -35,23 +35,22 @@
   <refsect1>
     <title>Description</title>
 
-    <para><command>systemd-sysusers</command> creates system users and
-    groups, based on the file format and location specified in
+    <para><command>systemd-sysusers</command> creates system users and groups, based on files in the format
+    described in
     <citerefentry><refentrytitle>sysusers.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
     </para>
 
-    <para>If invoked with no arguments, it applies all directives from all files
-    found in the directories specified by
-    <citerefentry><refentrytitle>sysusers.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
-    When invoked with positional arguments, if option
-    <option>--replace=<replaceable>PATH</replaceable></option> is specified, arguments
-    specified on the command line are used instead of the configuration file
-    <replaceable>PATH</replaceable>. Otherwise, just the configuration specified by
-    the command line arguments is executed. The string <literal>-</literal> may be
-    specified instead of a filename to instruct <command>systemd-sysusers</command>
-    to read the configuration from standard input. If only the basename of a file is
-    specified, all configuration directories are searched for a matching file and
-    the file found that has the highest priority is executed.</para>
+    <para>If invoked with no arguments, it applies all directives from all files found in the directories
+    specified by
+    <citerefentry><refentrytitle>sysusers.d</refentrytitle><manvolnum>5</manvolnum></citerefentry>. When
+    invoked with positional arguments, if option <option>--replace=<replaceable>PATH</replaceable></option>
+    is specified, arguments specified on the command line are used instead of the configuration file
+    <replaceable>PATH</replaceable>. Otherwise, just the configuration specified by the command line
+    arguments is executed. The string <literal>-</literal> may be specified instead of a filename to instruct
+    <command>systemd-sysusers</command> to read the configuration from standard input. If the argument is a
+    relative path, all configuration directories are searched for a matching file and the file found that has
+    the highest priority is executed. If the argument is an absolute path, that file is used directly without
+    searching of the configuration directories.</para>
   </refsect1>
 
   <refsect1>


### PR DESCRIPTION
This new xml file is needed by the XML manpages since commit c9a58e907a68106d5fb4f9f81565d38ed8b77e0e, but I forgot to add it when submitting the patch. Without it, manpages can't be generated.